### PR TITLE
Fixes link to Chatbot examples in skypilot repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Run LLaMA LLM chatbots on any cloud with one click
 
 This repository contains a simple demonstration of how to utilize the [LLaMA](https://github.com/facebookresearch/llama/tree/main) model as a chatbot.
-Please check out the [SkyPilot LLaMA example](https://github.com/skypilot-org/skypilot/tree/master/examples/llama-llm-chatbots) for comprehensive instructions.
+Please check out the [SkyPilot LLaMA example](https://github.com/skypilot-org/skypilot/tree/master/llm/llama-chatbots) for comprehensive instructions.


### PR DESCRIPTION
The same link on the blog here is also broken https://blog.skypilot.co/llama-llm-chatbots-on-any-cloud but I wasn't sure if there was a repo associated with it.